### PR TITLE
Using a single-threaded linking to optimize further

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rust:
 services:
   - docker
 before_install:
-  - docker pull clux/muslrust
+  - docker pull polyverse/rust-dev-env
 script:
   - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t polyverse/rust-dev-env cargo clippy
   - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t polyverse/rust-dev-env cargo test
-  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t clux/muslrust cargo build --release
+  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t polyverse/rust-dev-env cargo build --release
 deploy:
 # Be sure to add a GITHUB_TOKEN environment variable in this job's config
 # which the "Public Repos" permission, to enable pushing releases.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
 before_install:
   - docker pull clux/muslrust
 script:
-  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t clux/muslrust cargo test
-  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t clux/muslrust  /bin/bash -c "rustup component add clippy && cargo clippy"
+  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t polyverse/rust-dev-env cargo clippy
+  - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t polyverse/rust-dev-env cargo test
   - docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -t clux/muslrust cargo build --release
 deploy:
 # Be sure to add a GITHUB_TOKEN environment variable in this job's config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,6 @@ pretty_assertions = "0.6.1"
 
 # Enable LTO for release (since it only builds in Travis and doesn't block day to day)
 [profile.release]
-lto = true
+lto = "fat"
+codegen-units = 1
+

--- a/build-container.sh
+++ b/build-container.sh
@@ -2,4 +2,4 @@
 
 #docker run --rm -it -v $PWD:/zerotect --privileged rust bash
 
-docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -it --privileged clux/muslrust /bin/bash -c "rustup component add clippy && cargo install cargo-bloat && bash" 
+docker run -v cargo-cache:/root/.cargo/registry -v $PWD:/volume --rm -it --privileged polyverse/rust-dev-env

--- a/src/analyzer/close_by_ip_detect.rs
+++ b/src/analyzer/close_by_ip_detect.rs
@@ -1,12 +1,13 @@
+use crate::common;
 use crate::events;
 use crate::params;
-use crate::common;
 
 use chrono::{DateTime, Utc};
 use std::collections::VecDeque;
 use std::sync::Arc;
 
 pub fn close_by_ip_detect(
+    procname: &str,
     eventslist: &VecDeque<(DateTime<Utc>, events::Event)>,
     ip_max_distance: usize,
     justification_threshold: usize,
@@ -61,6 +62,7 @@ pub fn close_by_ip_detect(
                 event: events::EventType::RegisterProbe(events::RegisterProbe {
                     register: "ip".to_owned(),
                     message: "Instruction Pointer probe".to_owned(),
+                    procname: procname.to_owned(),
                     justification: justify(close_by_ip.clone(), justification_kind),
                 }),
             }),

--- a/src/analyzer/close_by_register_detect.rs
+++ b/src/analyzer/close_by_register_detect.rs
@@ -7,6 +7,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 pub fn close_by_register_detect(
+    procname: &str,
     eventslist: &VecDeque<(DateTime<Utc>, events::Event)>,
     register: &str,
     register_max_distance: usize,
@@ -75,6 +76,7 @@ pub fn close_by_register_detect(
                 event: events::EventType::RegisterProbe(events::RegisterProbe {
                     register: register.to_owned(),
                     message: message.to_owned(),
+                    procname: procname.to_owned(),
                     justification: justify(close_by_register.clone(), register, justification_kind),
                 }),
             }),

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -87,21 +87,26 @@ impl Analyzer {
             let mut detected_events: Vec<events::Event> = vec![];
             let mut used_events: Vec<events::Event> = vec![];
 
-            for (_, eventslist) in self.event_buffer.iter_mut() {
+            for (procname, eventslist) in self.event_buffer.iter_mut() {
                 // do we have at least 2 events?
                 if eventslist.len() <= 1 {
                     continue; // not enough to do anything reasonable
                 }
 
-                if let Some((detected_event, mut events_used_for_detection)) =
-                    close_by_ip_detect(eventslist, self.ip_max_distance, 1, self.justification_kind)
-                {
+                if let Some((detected_event, mut events_used_for_detection)) = close_by_ip_detect(
+                    procname,
+                    eventslist,
+                    self.ip_max_distance,
+                    1,
+                    self.justification_kind,
+                ) {
                     detected_events.push(detected_event);
                     used_events.append(&mut events_used_for_detection)
                 }
 
                 if let Some((detected_event, mut events_used_for_detection)) =
                     close_by_register_detect(
+                        procname,
                         eventslist,
                         "RDI",
                         1,
@@ -116,6 +121,7 @@ impl Analyzer {
 
                 if let Some((detected_event, mut events_used_for_detection)) =
                     close_by_register_detect(
+                        procname,
                         eventslist,
                         "RSI",
                         1,
@@ -130,6 +136,7 @@ impl Analyzer {
 
                 if let Some((detected_event, mut events_used_for_detection)) =
                 close_by_register_detect(
+                    procname,
                     eventslist,
                     "RIP",
                     1,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,4 @@
-use num::{Unsigned, Integer};
+use num::{Integer, Unsigned};
 use std::any::type_name;
 use std::fmt::Display;
 use std::str::FromStr;


### PR DESCRIPTION
# Description

Uses a single-threaded compile for release to optimize the size a bit further (even though compile times might be slower.)

Also updated some CEF field names.

Fixes # (issue)
